### PR TITLE
CI: pin actionlint to v1.7.0

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,11 +1,12 @@
+---
 name: Actionlint
 
-on:
+'on':
   pull_request:
     paths:
       - '.github/workflows/**'
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - '.github/workflows/**'
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,13 +1,17 @@
 name: Actionlint
 
 on:
-  push:
-    paths:
-      - '.github/workflows/**'
-      - '.github/workflows/actionlint.yml'
   pull_request:
     paths:
       - '.github/workflows/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   actionlint:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,13 +1,18 @@
+---
 name: ShellCheck
 
-on:
-  push:
-    paths:
-      - 'fedora-setup.sh'
-      - '.github/workflows/shellcheck.yml'
+'on':
   pull_request:
     paths:
       - 'fedora-setup.sh'
+  push:
+    branches: [main]
+    paths:
+      - 'fedora-setup.sh'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   shellcheck:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,12 +1,13 @@
+---
 name: Yamllint
 
-on:
+'on':
   pull_request:
     paths:
       - '**/*.yml'
       - '**/*.yaml'
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - '**/*.yml'
       - '**/*.yaml'

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,14 +1,19 @@
 name: Yamllint
 
 on:
-  push:
-    paths:
-      - '**/*.yml'
-      - '**/*.yaml'
   pull_request:
     paths:
       - '**/*.yml'
       - '**/*.yaml'
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   yamllint:


### PR DESCRIPTION
Summary

Fix CI failures and improve workflow hygiene without changing runtime behavior.

Changes

- Pin actionlint to a working tag: `rhysd/actionlint@v1.7.0` (resolves action download error).
- Tidy triggers to avoid duplicate runs:
  - Run on pull_request for relevant paths.
  - Run on push only on `main`.
- Add `concurrency` to cancel superseded runs per workflow/ref.
- Satisfy yamllint style rules across workflows:
  - Add leading document start `---`.
  - Quote YAML key `on` as `'on'`.
  - Tighten list spacing (e.g., `branches: [main]`).

Files

- `.github/workflows/actionlint.yml`
- `.github/workflows/yamllint.yml`
- `.github/workflows/shellcheck.yml`

Impact

- CI-only. Eliminates action resolution errors and duplicate runs.
- Linters should pass; pre-merge checks remain effective without noise.
